### PR TITLE
Replace module attribute with function

### DIFF
--- a/lib/intercom/api/request.ex
+++ b/lib/intercom/api/request.ex
@@ -1,14 +1,12 @@
 defmodule Intercom.API.Request do
   @moduledoc false
 
-  @http_adapter Application.get_env(:intercom, :http_adapter)
-
   def make_request(:get, url, headers, nil) do
-    @http_adapter.get(url, headers, []) |> parse_response()
+    http_adapter().get(url, headers, []) |> parse_response()
   end
 
   def make_request(:post, url, headers, body) do
-    @http_adapter.post(url, Jason.encode!(body), headers, []) |> parse_response()
+    http_adapter().post(url, Jason.encode!(body), headers, []) |> parse_response()
   end
 
   defp parse_response({:ok, %HTTPoison.Response{status_code: 200, body: body} = response}) do
@@ -26,4 +24,8 @@ defmodule Intercom.API.Request do
   end
 
   defp parse_response({:error, error}), do: {:error, error}
+
+  defp http_adapter() do
+    Application.get_env(:intercom, :http_adapter)
+  end
 end


### PR DESCRIPTION
fixes #8 

Accessing `&Application.get_env/2` from a module attribute means that
attribute is filled at compile time. At compile time, the environment
might be different than at runtime and depends on the compile method.

Using a function to access the http_adapter means that the library
always reads from the runtime environment. This leads to reliable
results and does not depend on specific compile methods.