### PR TITLE
Fix missing module error in Elixir release

### DIFF
--- a/lib/intercom.ex
+++ b/lib/intercom.ex
@@ -41,8 +41,8 @@ defmodule Intercom do
           _ ->
             Map.merge(opts, %{
               :user_hash =>
-                :hmac
-                |> :crypto.mac(:sha256, secret, Map.fetch!(opts, key))
+                :sha256
+                |> hmac(secret, Map.fetch!(opts, key))
                 |> Base.encode16()
                 |> String.downcase()
               })
@@ -64,5 +64,11 @@ defmodule Intercom do
         {:ok, base <> Generator.generate(tree) <> ";</script>"}
       x -> x
     end
+  end
+
+  if Code.ensure_loaded?(:crypto) and function_exported?(:crypto, :mac, 4) do
+    defp hmac(digest, key, payload), do: :crypto.mac(:hmac, digest, key, payload)
+  else
+    defp hmac(digest, key, payload), do: :crypto.hmac(digest, key, payload)
   end
 end

--- a/lib/intercom.ex
+++ b/lib/intercom.ex
@@ -38,11 +38,14 @@ defmodule Intercom do
       key ->
         {:ok, case secret do
           nil -> opts
-          _ -> Map.merge(opts, %{:user_hash => :sha256
-            |> :crypto.hmac(secret, Map.fetch!(opts, key))
-            |> Base.encode16
-            |> String.downcase
-          })
+          _ ->
+            Map.merge(opts, %{
+              :user_hash =>
+                :hmac
+                |> :crypto.mac(:sha256, secret, Map.fetch!(opts, key))
+                |> Base.encode16()
+                |> String.downcase()
+              })
         end}
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule Intercom.Mixfile do
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      package: package(),
-     deps: deps]
+     deps: deps()]
   end
 
   # Configuration for the OTP application

--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,7 @@ defmodule Intercom.Mixfile do
   #
   # Type "mix help compile.app" for more information
   def application do
-    [applications: [:logger]]
+    [applications: [:estree, :logger]]
   end
 
   # Dependencies can be Hex packages:


### PR DESCRIPTION
I'm deploying app using Elixir release and in production I was getting this error:

```
** (UndefinedFunctionError) function ESTree.Tools.Builder.identifier/1 is undefined (module ESTree.Tools.Builder is not available)
  ESTree.Tools.Builder.identifier(:Intercom)
  (intercom 0.0.1) lib/intercom.ex:21: Intercom.boot/1
  (intercom 0.0.1) lib/intercom.ex:16: Intercom.boot/1
  (intercom 0.0.1) lib/intercom.ex:58: Intercom.snippet/2
```

This PR fixes the error by defining `estree` dependency as a runtime to be included in the release.